### PR TITLE
BLD: pin extension-helpers to 1.* following upstream recommendation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 requires = ["setuptools",
             "setuptools_scm",
             "wheel",
-            "extension-helpers",
+            "extension-helpers==1.*",
             "oldest-supported-numpy",
             "cython==0.29.14"]
 


### PR DESCRIPTION
Following https://github.com/astropy/extension-helpers/pull/72